### PR TITLE
Remove fallback for polling using iframe in old IE (<= IE7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "testling": {
     "html": "test/location_bar_test.html",
     "browsers": [
-      "ie/6..latest",
+      "ie/8..latest",
       "chrome/20..latest",
       "firefox/10..latest",
       "safari/latest",


### PR DESCRIPTION
Removes support for IE7 and below.

IE7 is unmaintained browser with 0,03% of usage